### PR TITLE
Ticket #394137: Quickfilter doesn't work correctly

### DIFF
--- a/ontimize-core-client/src/main/java/com/ontimize/gui/table/Table.java
+++ b/ontimize-core-client/src/main/java/com/ontimize/gui/table/Table.java
@@ -18446,7 +18446,12 @@ public class Table extends JRootPane
 		public void actionPerformed(ActionEvent e) {
 			this.table.getQuickFilter().getTimer().stop();
 			if ((this.table.getPageFetcher() != null) && this.table.getPageFetcher().isPageableEnabled() && !this.table.isQuickFilterLocal()) {
-				this.executeQuery();
+				try {
+					this.table.getQuickFilter().setEnabled(false);
+					this.executeQuery();
+				} finally {
+					this.table.getQuickFilter().setEnabled(true);
+				}
 			} else {
 				this.applyFilter();
 			}


### PR DESCRIPTION
Fixed. The Quickfilter field is blocked until the query is finished, then it is enabled again